### PR TITLE
Add Cookie Domain support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This repository builds a Docker Image that protects an upstream server using [Ok
 
 ### Optional
 
+- `COOKIE_DOMAIN` - Defaults to current domain only.  Set in order to allow use on subdomains.
 - `COOKIE_NAME` - Defaults to `okta-jwt`. The name of the cookie that holds the Authorization Token
 - `INJECT_REFRESH_JS` - Defaults to `true`.  Set to `false` to disable injection of JavaScript that transparently refreshes Access Tokens when they are close to expiring
 - `LISTEN` - Defaults to `80`.  Specify another port to change the listening port number.  See [nginx listen](http://nginx.org/en/docs/http/ngx_http_core_module.html#listen) for options, such as TLS and unix sockets

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -14,6 +14,7 @@ docker run \
     -e "AUDIENCE=$AUDIENCE" \
     -e "CLIENT_ID=$CLIENT_ID" \
     -e "CLIENT_SECRET=$CLIENT_SECRET" \
+    -e "COOKIE_DOMAIN=$COOKIE_DOMAIN" \
     -e "ISSUER=$ISSUER" \
     -e "LOGIN_REDIRECT_URL=$LOGIN_REDIRECT_URL" \
     -p "8080:80" \

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,13 @@ module github.com/boxboat/okta-nginx
 require (
 	github.com/caleblloyd/okta-jwt-verifier-golang v0.0.0-20180727134137-2d2b68fc61a4
 	github.com/davecgh/go-spew v1.1.0
+	github.com/google/pprof v0.0.0-20190109223431-e84dfd68c163 // indirect
+	github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 // indirect
 	github.com/lestrrat-go/jwx v0.0.0-20180716092526-0e3622ae3e83
 	github.com/lestrrat-go/pdebug v0.0.0-20180220043849-39f9a71bcabe
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pkg/errors v0.8.0
+	golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045 // indirect
+	golang.org/x/crypto v0.0.0-20190128193316-c7b33c32a30b // indirect
+	golang.org/x/sys v0.0.0-20190124100055-b90733256f2e // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,10 @@
 github.com/caleblloyd/okta-jwt-verifier-golang v0.0.0-20180727134137-2d2b68fc61a4 h1:EcwJLGdvQR07K0eiiA/zJyzRhAZhpxg5rwm8kDt74Tw=
 github.com/caleblloyd/okta-jwt-verifier-golang v0.0.0-20180727134137-2d2b68fc61a4/go.mod h1:yDtd8VuJIHxoSBcBKphyq3OQL4P7df3Kc6l0Is/sjlM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/pprof v0.0.0-20190109223431-e84dfd68c163 h1:beB+Da4k9B1zmgag78k3k1Bx4L/fdWr5FwNa0f8RxmY=
+github.com/google/pprof v0.0.0-20190109223431-e84dfd68c163/go.mod h1:zfwlbNMJ+OItoe0UupaVj+oy1omPYYDuagoSzA8v9mc=
+github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6 h1:UDMh68UUwekSh5iP2OMhRRZJiiBccgV7axzUG8vi56c=
+github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/lestrrat-go/jwx v0.0.0-20180716092526-0e3622ae3e83 h1:mM/qDuuc52P4e/H65w5ILSmgyUalNDoARXIjOCJiEYE=
 github.com/lestrrat-go/jwx v0.0.0-20180716092526-0e3622ae3e83/go.mod h1:iEoxlYfZjvoGpuWwxUz+eR5e6KTJGsaRcy/YNA/UnBk=
 github.com/lestrrat-go/pdebug v0.0.0-20180220043849-39f9a71bcabe h1:S7XSBlgc/eI2v47LkPPVa+infH3FuTS4tPJbqCtJovo=
@@ -9,3 +13,9 @@ github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaR
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pkg/errors v0.8.0 h1:WdK/asTD0HN+q6hsWO3/vpuAkAr+tw6aNJNDFFf0+qw=
 github.com/pkg/errors v0.8.0/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
+golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045 h1:Pn8fQdvx+z1avAi7fdM2kRYWQNxGlavNDSyzrQg2SsU=
+golang.org/x/arch v0.0.0-20181203225421-5a4828bb7045/go.mod h1:cYlCBUl1MsqxdiKgmc4uh7TxZfWSFLOGSRR090WDxt8=
+golang.org/x/crypto v0.0.0-20190128193316-c7b33c32a30b h1:Ib/yptP38nXZFMwqWSip+OKuMP9OkyDe3p+DssP8n9w=
+golang.org/x/crypto v0.0.0-20190128193316-c7b33c32a30b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/sys v0.0.0-20190124100055-b90733256f2e h1:3GIlrlVLfkoipSReOMNAgApI0ajnalyLa/EZHHca/XI=
+golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/stage/etc/nginx/conf.d/detect.conf
+++ b/stage/etc/nginx/conf.d/detect.conf
@@ -1,0 +1,24 @@
+map $http_x_forwarded_proto $detect_proto_untrusted {
+    default $http_x_forwarded_proto;
+    ""      $scheme;
+}
+
+map $trusted_addr $detect_proto {
+    default $scheme;
+    1       $detect_proto_untrusted;
+}
+
+map $http_x_forwarded_host $detect_host_untrusted {
+    default $http_x_forwarded_host;
+    ""      $http_host;
+}
+
+map $trusted_addr $detect_host {
+    default $http_host;
+    1       $detect_host_untrusted;
+}
+
+map $http_connection $detect_connection {
+    default "";
+    ~*^upgrade $http_connection;
+}

--- a/stage/etc/nginx/conf.d/real-ip.conf
+++ b/stage/etc/nginx/conf.d/real-ip.conf
@@ -5,3 +5,11 @@ set_real_ip_from 10.0.0.0/8;
 set_real_ip_from 172.16.0.0/12;
 set_real_ip_from 192.168.0.0/16;
 set_real_ip_from fd00::/8;
+
+geo $realip_remote_addr $trusted_addr {
+    default        0;
+    10.0.0.0/8     1;
+    172.16.0.0/12  1;
+    192.168.0.0/16 1;
+    fd00::/8       1;
+}

--- a/stage/etc/nginx/includes/proxy-headers.conf
+++ b/stage/etc/nginx/includes/proxy-headers.conf
@@ -2,6 +2,8 @@
 proxy_http_version 1.1;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+proxy_set_header X-Forwarded-Proto $detect_proto;
+proxy_set_header X-Forwarded-Host $detect_host;
 proxy_set_header Host $host;
-proxy_set_header Connection $http_connection;
+proxy_set_header Connection $detect_connection;
 proxy_set_header Upgrade $http_upgrade;

--- a/stage/var/okta-nginx/refresh.js
+++ b/stage/var/okta-nginx/refresh.js
@@ -11,7 +11,7 @@
     /// handle window.postMessage event
     function wl(e){
         console.log('wl');
-        if (e.origin !== 'http://localhost:8080'){
+        if (e.origin !== window.location.protocol + "//" + window.location.host){
             return;
         }
         if (e.data === 'ssoRefreshDone'){
@@ -67,8 +67,9 @@
         x.addEventListener("abort", xe);
         x.addEventListener("error", xe);
         x.addEventListener("timeout", xe);
-        x.open("GET", "http://localhost:8080/sso/refresh/check");
+        x.open("GET", "/sso/refresh/check");
         x.timeout=10000;
+        x.withCredentials=true;
         x.send();
     }
     xr();

--- a/vars-example.env
+++ b/vars-example.env
@@ -1,5 +1,7 @@
+export AUDIENCE="api://default"
 export CLIENT_ID="xxxxxx"
 export CLIENT_SECRET="xxxxx"
+export COOKIE_DOMAIN=""
 export ISSUER="https://xxxxx.oktapreview.com/oauth2/default"
 export LOGIN_REDIRECT_URL="http://localhost:8080/sso/authorization-code/callback"
 export REQUEST_TIMEOUT="5"


### PR DESCRIPTION
Currently, the Cookie Domain is not set, so it defaults to the current domain only

This PR adds the COOKIE_DOMAIN environment variable, which allows for subdomains to read the JWT cookie.  This allows NGINX to proxy any valid subdomain that matches the COOKIE_DOMAIN.