### PR TITLE
Add option for multiple servers

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ This repository builds a Docker Image that protects an upstream server using [Ok
 - `INJECT_REFRESH_JS` - Defaults to `true`.  Set to `false` to disable injection of JavaScript that transparently refreshes Access Tokens when they are close to expiring
 - `LISTEN` - Defaults to `80`.  Specify another port to change the listening port number.  See [nginx listen](http://nginx.org/en/docs/http/ngx_http_core_module.html#listen) for options, such as TLS and unix sockets
 - `REQUEST_TIMEOUT` - Defaults to `5`.  Timeout for calling the Okta `token` endpoint to retrieve an Authorization Token
+- `SERVER_NAME` - Defaults to `_`.  See [nginx server_name](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_name) for options.
 - `SSO_PATH` - Defaults to `/sso/`. Path for SSO error and refresh endpoints.  Should include leading and trailing slash
 
 ## Authenticated Headers Passed to Upstream Server
@@ -46,3 +47,20 @@ Any files added to `/etc/nginx/conf.d` will be included in the `http` block.
 ### Adding Configuration to the `server` block
 
 Any content in the file `/etc/nginx/includes/default-server.conf` will be included in the default `server` block.
+
+## Multiple Servers
+
+Multiple servers are supported by incrementing a number starting with 2 to select environment variables.
+
+- Server 2
+    - `LISTEN_2`: required
+    - `SERVER_NAME_2`: required
+    - `PROXY_PASS_2`: required
+    - optionally add configuration to `/etc/nginx/includes/default-server.2.conf`
+- Server N
+    - `LISTEN_N`: required
+    - `SERVER_NAME_N`: required
+    - `PROXY_PASS_N`: required
+    - optionally add configuration to `/etc/nginx/includes/default-server.N.conf`
+
+Multiple servers all use the same Okta Authorization Server and the same `LOGIN_REDIRECT_URL`.  Multiple servers should either be on the same host with different ports, or on subdomains are all valid for `COOKIE_DOMAIN`.

--- a/stage/etc/nginx/conf.d/auth-server.conf
+++ b/stage/etc/nginx/conf.d/auth-server.conf
@@ -1,0 +1,3 @@
+upstream auth_server {
+    server unix:/var/run/auth.sock;
+}

--- a/stage/etc/nginx/includes/proxy-protect.conf
+++ b/stage/etc/nginx/includes/proxy-protect.conf
@@ -1,0 +1,4 @@
+error_page 401 @error401;
+include /etc/nginx/includes/proxy-headers.conf;
+include /etc/nginx/includes/refresh-js.conf;
+proxy_set_header X-Forwarded-User $auth_request_user;

--- a/stage/etc/nginx/templates/default.conf
+++ b/stage/etc/nginx/templates/default.conf
@@ -1,13 +1,9 @@
-upstream auth_server {
-    server unix:/var/run/auth.sock;
-}
-
 server {
     listen ${LISTEN};
-    server_name _;
+    server_name ${SERVER_NAME};
 
     # additional configuration for default_server
-    include /etc/nginx/includes/default-server.conf;
+    include /etc/nginx/includes/default-server${SERVER_SUFFIX}.conf;
 
     # auth_request settinggs
     auth_request @auth;
@@ -32,10 +28,7 @@ server {
 
     # default location
     location / {
-        error_page 401 @error401;
-        include /etc/nginx/includes/proxy-headers.conf;
-        include /etc/nginx/includes/refresh-js.conf;
-        proxy_set_header X-Forwarded-User $auth_request_user;
+        include /etc/nginx/includes/proxy-protect.conf;
         proxy_pass ${PROXY_PASS};
     }
 

--- a/stage/var/okta-nginx/refresh-minify.sh
+++ b/stage/var/okta-nginx/refresh-minify.sh
@@ -9,7 +9,6 @@ echo '<script type="text/javascript">'$(\
     | sed -r 's|///.*||g' \
     | sed ':a;N;$!ba;s/\n/ /g' \
     | sed -r 's/\s+/ /g' \
-    | sed -r "s|http://localhost:8080|${1}|g" \
-    | sed -r "s|/sso/|${2}|g" \
+    | sed -r "s|/sso/|${1}|g" \
     | sed -r "s/'/\\\'/g"
 )'</script>'

--- a/stage/var/okta-nginx/refresh.js
+++ b/stage/var/okta-nginx/refresh.js
@@ -2,7 +2,6 @@
 /// this code is minifed by refresh-minify.sh
 /// all comments should start with 3 forward slashes
 /// all statements should end in semicolons
-/// the app origin should be referred to as http://localhost:8080
 /// the sso path should be referred to as /sso/
 (function(){
     /// iframe variable


### PR DESCRIPTION
Multiple servers can be useful if there are separate server names that may need to be proxied.

This PR adds code that generates multiple servers with different options for:
- `LISTEN`
- `SERVER_NAME`
- `PROXY_PASS`

This DOES NOT add code to deal with multiple Okta Authorization Servers or use multiple LOGIN_REDIRECT_URLs.  Multiple servers should be on the same host with different ports, or on subdomains that all match `COOKIE_DOMAIN`.