### PR TITLE
Add optional validation of Boolean claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ This repository builds a Docker Image that protects an upstream server using [Ok
 - `SERVER_NAME` - Defaults to `_`.  See [nginx server_name](http://nginx.org/en/docs/http/ngx_http_core_module.html#server_name) for options.
 - `SSO_PATH` - Defaults to `/sso/`. Path for SSO error and refresh endpoints.  Should include leading and trailing slash
 - `USE_PROXY_PASS` - Defaults to `true`.  Set to `false` to use configuration in `server` block instead.
+- `VALIDATE_BOOLEAN_CLAIMS` - Set to space separated list of boolean claims to require.
 
 ## Authenticated Headers Passed to Upstream Server
 
@@ -58,12 +59,14 @@ Multiple servers are supported by incrementing a number starting with 2 to selec
     - `SERVER_NAME_2`: required
     - `PROXY_PASS_2`: required unless `USE_PROXY_PASS_2` is `false`
     - `USE_PROXY_PASS_2`: optional
+    - `VALIDATE_BOOLEAN_CLAIMS_2`: optional
     - optionally add configuration to `/etc/nginx/includes/default-server.2.conf`
 - Server N
     - `LISTEN_N`: required
     - `SERVER_NAME_N`: required
     - `PROXY_PASS_N`: required unless `USE_PROXY_PASS_N` is `false`
     - `USE_PROXY_PASS_N`: optional
+    - `VALIDATE_BOOLEAN_CLAIMS_2`: optional
     - optionally add configuration to `/etc/nginx/includes/default-server.N.conf`
 
 Multiple servers all use the same Okta Authorization Server and the same `LOGIN_REDIRECT_URL`.  Multiple servers should either be on the same host with different ports, or on subdomains are all valid for `COOKIE_DOMAIN`.

--- a/stage/etc/nginx/templates/default.conf
+++ b/stage/etc/nginx/templates/default.conf
@@ -15,6 +15,7 @@ server {
         include /etc/nginx/includes/proxy-headers.conf;
         proxy_pass_request_body off;
         proxy_set_header Content-Length "";
+        proxy_set_header X-Okta-Validate-Boolean-Claims "${VALIDATE_BOOLEAN_CLAIMS}";
         proxy_pass http://auth_server$request_uri;
     }
 

--- a/stage/usr/local/bin/run.sh
+++ b/stage/usr/local/bin/run.sh
@@ -65,6 +65,7 @@ while : ; do
     export PROXY_PASS=$(eval echo "\$PROXY_PASS${env_var_suffix}")
     export SERVER_NAME=$(eval echo "\$SERVER_NAME${env_var_suffix}")
     export USE_PROXY_PASS=$(eval echo "\$USE_PROXY_PASS${env_var_suffix}")
+    export VALIDATE_BOOLEAN_CLAIMS=$(eval echo "\$VALIDATE_BOOLEAN_CLAIMS${env_var_suffix}")
     if [ -z "$LISTEN" -o -z "$SERVER_NAME" ]; then
         break
     fi
@@ -84,7 +85,7 @@ while : ; do
     fi
 
     # stamp out default.conf template
-    envsubst '${APP_REDIRECT_PATH},${LISTEN},${SERVER_NAME},${SERVER_SUFFIX},${SSO_PATH}' \
+    envsubst '${APP_REDIRECT_PATH},${LISTEN},${SERVER_NAME},${SERVER_SUFFIX},${SSO_PATH},${VALIDATE_BOOLEAN_CLAIMS}' \
         < /etc/nginx/templates/default.conf \
         > "/etc/nginx/conf.d/default${SERVER_SUFFIX}.conf"
 


### PR DESCRIPTION
This PR adds the optional `$VALIDATE_BOOLEAN_CLAIMS` environment variable

Setting this to a space delimited list of claims will check the JWT to ensure that each of the claims is `true`, otherwise it will return 401 Unauthorized