### PR TITLE
Proxy all requests to /auth/validate with Request URI in header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.11.2-alpine3.8 AS build
+FROM golang:1.12.4-alpine3.9 AS build
 
 ENV CGO_ENABLED=0
 

--- a/stage/etc/nginx/templates/default.conf
+++ b/stage/etc/nginx/templates/default.conf
@@ -10,8 +10,9 @@ server {
         include /etc/nginx/includes/proxy-headers.conf;
         proxy_pass_request_body off;
         proxy_set_header Content-Length "";
-        proxy_set_header X-Okta-Validate-Claims-Template '${VALIDATE_CLAIMS_TEMPLATE}';
-        proxy_pass http://auth_server$request_uri;
+        proxy_set_header X-Okta-Nginx-Request-Uri $request_uri;
+        proxy_set_header X-Okta-Nginx-Validate-Claims-Template '${VALIDATE_CLAIMS_TEMPLATE}';
+        proxy_pass http://auth_server/auth/validate;
     }
 
     # auth_request failed


### PR DESCRIPTION
Applications may sometimes present invalid URIs

Applications may know how to handle invalid URIs, but Go's HTTP server will 301 these invalid URIs:

```
# curl -i --unix-socket /var/run/auth.sock http:/test//test
HTTP/1.1 301 Moved Permanently
Content-Type: text/html; charset=utf-8
Location: /test
Date: Fri, 03 May 2019 18:31:55 GMT
Content-Length: 40

<a href="/test">Moved Permanently</a>.
```

301 is not a valid [auth_request](http://nginx.org/en/docs/http/ngx_http_auth_request_module.html) response, so NGINX will serve a 500 error

This PR changes the Go server to receive all `auth_request` requests on the path `/auth/validate` and read the original Request URI from the `X-Okta-Nginx-Request-Uri` header