### PR TITLE
Okta production

### DIFF
--- a/server.go
+++ b/server.go
@@ -236,14 +236,14 @@ func validateCookieHandler(w http.ResponseWriter, r *http.Request, conf *config)
 
 	sub, ok := jwt.Claims["sub"]
 	if !ok {
-		log.Printf("validateCookieHandler: Claim 'sub' not included in access token, %v", tokenCookie.Value)
+		log.Printf("validateCookieHandler: Claim 'sub' not included in id token, %v", tokenCookie.Value)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
 
 	subStr, ok := sub.(string)
 	if !ok {
-		log.Printf("validateCookieHandler: Unable to convert 'sub' to string in access token, %v", tokenCookie.Value)
+		log.Printf("validateCookieHandler: Unable to convert 'sub' to string in id token, %v", tokenCookie.Value)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -329,7 +329,7 @@ func callbackHandler(w http.ResponseWriter, r *http.Request, conf *config) {
 	exp, ok := jwt.Claims["exp"]
 	if !ok {
 		w.WriteHeader(http.StatusInternalServerError)
-		log.Printf("refreshHandler: Claim 'exp' not included in access token, %v", jwtStr)
+		log.Printf("refreshHandler: Claim 'exp' not included in id token, %v", jwtStr)
 		return
 	}
 
@@ -396,7 +396,7 @@ func refreshCheckHandler(w http.ResponseWriter, r *http.Request, conf *config) {
 
 	exp, ok := jwt.Claims["exp"]
 	if !ok {
-		log.Printf("refreshCheckHandler: Claim 'exp' not included in access token, %v", tokenCookie.Value)
+		log.Printf("refreshCheckHandler: Claim 'exp' not included in id token, %v", tokenCookie.Value)
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
@@ -486,7 +486,7 @@ func errorHandler(w http.ResponseWriter, r *http.Request, conf *config) {
 	}
 }
 
-//getJWT queries the okta server with an access code.  A valid request will return a JWT access token.
+//getJWT queries the okta server with an access code.  A valid request will return a JWT id token.
 func getJWT(code string, conf *config) (string, error) {
 	client := &http.Client{
 		Timeout: time.Second * conf.requestTimeout,

--- a/server.go
+++ b/server.go
@@ -26,16 +26,17 @@ import (
 const sock = "/var/run/auth.sock"
 
 type config struct {
-	appOrigin           string        //computed
-	clientID            string        //CLIENT_ID
-	clientSecret        string        //CLIENT_SECRET
-	cookieDomain        string        //COOKIE_DOMAIN
-	cookieDomainCheck   string        //computed
-	cookieName          string        //COOKIE_NAME
-	issuer              string        //ISSUER
-	loginRedirectURL    *url.URL      //LOGIN_REDIRECT_URL
-	oktaLoginBaseURLStr string        //computed
-	oktaOrigin          string        //computed
+	appOrigin           string   //computed
+	clientID            string   //CLIENT_ID
+	clientSecret        string   //CLIENT_SECRET
+	cookieDomain        string   //COOKIE_DOMAIN
+	cookieDomainCheck   string   //computed
+	cookieName          string   //COOKIE_NAME
+	issuer              string   //ISSUER
+	loginRedirectURL    *url.URL //LOGIN_REDIRECT_URL
+	oktaLoginBaseURLStr string   //computed
+	oktaOrigin          string   //computed
+	tokenEndpoint       string
 	ssoPath             string        //SSO_PATH
 	requestTimeout      time.Duration //Default of 5 seconds if no env set
 	verifier            *jwtverifier.JwtVerifier
@@ -144,6 +145,7 @@ func getConfig() *config {
 		"&nonce=123"
 
 	return &config{
+		tokenEndpoint:       metaData["token_endpoint"].(string),
 		appOrigin:           appOrigin,
 		clientID:            clientID,
 		clientSecret:        clientSecret,
@@ -499,7 +501,7 @@ func getJWT(code string, conf *config) (string, error) {
 		"&grant_type=authorization_code" +
 		"&scope=openid profile")
 
-	req, err := http.NewRequest("POST", conf.issuer+"/v1/token", bytes.NewBuffer(reqBody))
+	req, err := http.NewRequest("POST", conf.tokenEndpoint, bytes.NewBuffer(reqBody))
 	if err != nil {
 		return "", err
 	}

--- a/server.go
+++ b/server.go
@@ -122,7 +122,7 @@ func getConfig() *config {
 	metaData, err := getMetaData(issuer)
 
 	if err != nil {
-		log.Fatal("Could not retrieve metadata from issuer uri.")
+		log.Fatal("Could not retrieve metadata from Issuer URL.")
 	}
 
 	//Initialize validator


### PR DESCRIPTION
So I tested this repo using some Okta production account, and see three errors. 

1. Issuer URL. While in dev account there is an authorization server by default like {yourOktaDevDomain}/oauth2/default, the default authorization server for a production account is just the okta domain, but when you try to put just your okta domain, the application gives error 404 because the authorize path is ${yourOktaDomain}/oauth2/v1/authorize.

2. Issuer URL again. In package okta-jwt-verifier-golang has a method called getMetaData which get all the paths for oauth2 connections through the address /.well-known/openid-configuration.
https://developer.okta.com/docs/api/resources/oidc/#well-known-openid-configuration
Again, if we put issuer as ${yourOktaDomain}/oauth2 to bypass first error, we faced this one, because the metadata comes empty and give us a panic error.

3. Access Token, this is the most important. We are using Access Token to validate everything in this package. We can't, we have to use Id Token, because Access Token doesn't validate in production environment. Okta published this "mistake":
https://support.okta.com/help/s/article/Signature-Validation-Failed-on-Access-Token