### PR TITLE
update upgrade to use nginx sample

### DIFF
--- a/stage/etc/nginx/conf.d/detect.conf
+++ b/stage/etc/nginx/conf.d/detect.conf
@@ -26,14 +26,8 @@ map "$trusted_addr,$http_x_forwarded_proto" $detect_proto {
     default     $http_x_forwarded_proto;
 }
 
-# Connection
-map "$http_connection $http_upgrade" $detect_connection {
-    default                  "";
-    ~*.*upgrade.*websocket.* Upgrade;
-}
-
-# Upgrade
-map "$http_connection $http_upgrade" $detect_upgrade {
-    default                  "";
-    ~*.*upgrade.*websocket.* WebSocket;
+# http://nginx.org/en/docs/http/websocket.html
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
 }

--- a/stage/etc/nginx/includes/proxy-headers.conf
+++ b/stage/etc/nginx/includes/proxy-headers.conf
@@ -6,5 +6,5 @@ proxy_set_header X-Forwarded-Host $detect_host;
 proxy_set_header X-Forwarded-Port $detect_port;
 proxy_set_header X-Forwarded-Proto $detect_proto;
 proxy_set_header Host $host;
-proxy_set_header Connection $detect_connection;
-proxy_set_header Upgrade $detect_upgrade;
+proxy_set_header Connection $connection_upgrade;
+proxy_set_header Upgrade $http_upgrade;


### PR DESCRIPTION
WebSockets may not be the only protocol that apps need to upgrade

adopt the simpler nginx example to handling upgrade, which [ingress-nginx also uses](https://github.com/kubernetes/ingress-nginx/blob/0bc01f7c35410ce5cb07ee86ab530e99ae352026/rootfs/etc/nginx/template/nginx.tmpl#L386-L394)